### PR TITLE
Replace /data/logs with /data/vendor/logs

### DIFF
--- a/crashlog/Android.mk
+++ b/crashlog/Android.mk
@@ -57,7 +57,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH) \
 include $(LOCAL_PATH)/intel_specific/specific.mk
 
 # Options
-CRASHLOGD_LOGS_PATH := "/data/logs"
+CRASHLOGD_LOGS_PATH := "/data/vendor/logs"
 
 ifeq ($(MIXIN_DEBUG_LOGS),true)
 LOCAL_CFLAGS += -DFULL_REPORT -DCONFIG_APLOG -DCONFIG_USE_SD=FALSE \

--- a/crashlog/intel_specific/last_vmm_log.c
+++ b/crashlog/intel_specific/last_vmm_log.c
@@ -17,7 +17,7 @@
 /**
  * @file last_vmm_log.c
  * @brief File containing functions used to save the last vmm log.
- * Save the last vmm log to file /data/logs/last_vmm_log.
+ * Save the last vmm log to file /data/vendor/logs/last_vmm_log.
  */
 
 #include "fsutils.h"

--- a/crashlog/test_config.mk
+++ b/crashlog/test_config.mk
@@ -23,7 +23,7 @@
 # CRASHLOGD_COREDUMP := true
 # CRASHLOGD_EFILINUX := true
 # CRASHLOGD_FDK := true
-# CRASHLOGD_LOGS_PATH := "/data/logs"
+# CRASHLOGD_LOGS_PATH := "/data/vendor/logs"
 
 # Modules
 

--- a/log_service/aplog.sh
+++ b/log_service/aplog.sh
@@ -17,10 +17,10 @@
 # limitations under the License.
 #
 
-# This script is used to link /data/misc/logd/logcat.xxx to /data/logs/aplog.xxx
+# This script is used to link /data/misc/logd/logcat.xxx to /data/vendor/logs/aplog.xxx
 # to persistently save android aplication log and kernel log.
 
-APLOG_FILE_PATH=/data/logs/aplogs/aplog.
+APLOG_FILE_PATH=/data/vendor/logs/aplogs/aplog.
 LOGCAT_FILE_PATH=/data/misc/logd/logcat.
 LINK_TOOL=/vendor/bin/ln
 VENDOR_PRINTF=/vendor/bin/printf
@@ -40,7 +40,7 @@ start_link() {
 	do
 		sleep 1
 	done
-	[ -h /data/logs/aplogs/aplog ] || $LINK_TOOL -s /data/misc/logd/logcat /data/logs/aplogs/aplog
+	[ -h /data/vendor/logs/aplogs/aplog ] || $LINK_TOOL -s /data/misc/logd/logcat /data/vendor/logs/aplogs/aplog
 	while true
 	do
 		i=$((i+1))


### PR DESCRIPTION
/data/logs is needed by crashlogd, which is developed by Intel.
As a vendor domain, it should to store its data to /data/vendor
basing on the treble requirement.

Tracked-On: OAM-95647
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>