### PR TITLE
Fix fscanf overflow error

### DIFF
--- a/crashlog/history.c
+++ b/crashlog/history.c
@@ -49,7 +49,7 @@ static int nextline = -1;
 static unsigned int fileentries = 0;
 static int loop_uptime_event = 1;
 /* last uptime value set at device boot only */
-static char lastbootuptime[24] = "0000:00:00";
+static char lastbootuptime[25] = "0000:00:00";
 static char lastfakeprop[PROPERTY_VALUE_MAX] = "";
 extern int gabortcleansd;
 // global variable to enable dynamic change of uptime frequency


### PR DESCRIPTION
Fix the below fscanf overflow error:
error: 'fscanf' may overflow; destination buffer in argument 4
has size 24, but the corresponding specifier may require size
25 [-Werror,-Wfortify-source]
  fscanf(to, "#V1.0 %16s%24s\n", name, lastbootuptime);

Tracked-On: OAM-103588
Signed-off-by: svenate <salini.venate@intel.com>