### PR TITLE
Workaround for add Docker management service to auto boot

### DIFF
--- a/log_service/aplog.sh
+++ b/log_service/aplog.sh
@@ -61,6 +61,7 @@ start_link() {
 	done
 }
 
+/vendor/bin/docker_manager&
 
 start_link
 exit 0


### PR DESCRIPTION
Currrently, there may be some issues for init to start init.rc service, so temporaryly add Docker management daemon in aplog.sh to w/a it.

Signed-off-by: Wang, Liang <liang.wang@intel.com>