### PR TITLE
Save the lastest SYSTEM_LAST_KMSG from dropbox when boot up

### DIFF
--- a/crashlog/privconfig.h
+++ b/crashlog/privconfig.h
@@ -413,6 +413,7 @@ extern enum crashlog_mode g_crashlog_mode;
 #define LOG_FABRICTEMP           LOGS_DIR "/fabric_temp"
 #define CONSOLE_NAME            "console"
 #define LAST_KMSG_FILE          "last_kmsg"
+#define DROPBOX_LAST_KMSG       "SYSTEM_LAST_KMSG"
 #define CONSOLE_RAMOOPS_FILE    "console-ramoops"
 #define DMESG_RAMOOPS_FILE      "dmesg-ramoops"
 #define CONSOLE_RAMOOPS_FILE_NUM(x) "console-ramoops-"#x""


### PR DESCRIPTION

Dropbox generates a SYSTEM_LAST_KMSG file each time when the system reboot, power down, or crash. And this information could be very useful for debug. So we check the dropbox and copy its latest SYSTEM_LAST_KMSG file to the boot information folder. Check the history_event to find this folder and more information.

Tracked-On: OAM-111964