### PR TITLE
Fixing Coverity issue for log_capture

### DIFF
--- a/crashlog/crashutils.c
+++ b/crashlog/crashutils.c
@@ -169,6 +169,7 @@ static int find_system_last_kmsg(char source[], int source_length) {
 
     if (source == NULL) {
         LOGE("source is NULL.\n");
+        closedir(dir);
         return file_exist;
     }
     if (dir == NULL) {


### PR DESCRIPTION
Tests Done: Build and boot

Tracked-On: OAM-125083