### PR TITLE
coverity: fix coverity issue report in crashlog

### DIFF
--- a/crashlog/config.c
+++ b/crashlog/config.c
@@ -98,7 +98,7 @@ static void add_section(char *config, pconfig_handle  conf_handle) {
         conf_handle->current->next = newsect;
      }
     conf_handle->current = newsect;
-    newsect->name = malloc(strlen(config));
+    newsect->name = malloc(strlen(config) + 1);
     if(!newsect->name) {
         if(newsect) {
             free(newsect);

--- a/crashlog/crashutils.c
+++ b/crashlog/crashutils.c
@@ -164,13 +164,14 @@ unsigned long long get_uptime(int refresh, int *error)
 // Find system last kmsg from dropbox
 static int find_system_last_kmsg(char source[], int source_length) {
     struct dirent *entry;
-    DIR *dir = opendir(DROPBOX_DIR);
+    DIR *dir;
     int file_exist = 0;
 
     if (source == NULL) {
         LOGE("source is NULL.\n");
         return file_exist;
     }
+    dir = opendir(DROPBOX_DIR);
     if (dir == NULL) {
         LOGE("No such directory: %s\n",DROPBOX_DIR);
         return file_exist;
@@ -187,9 +188,9 @@ static int find_system_last_kmsg(char source[], int source_length) {
 }
 
 void do_last_kmsg_copy(char *dir) {
-    char destion[PATHMAX];
-    char source[PATHMAX];
+    char source[PATHMAX] = {0};
     char sourcepath[PATHMAX];
+    char destion[PATHMAX];
 
     if ( file_exists(LAST_KMSG) ) {
         snprintf(destion, sizeof(destion), "%s/%s", dir, LAST_KMSG_FILE);

--- a/crashlog/main.c
+++ b/crashlog/main.c
@@ -694,7 +694,7 @@ int do_monitor() {
         return -1;
     } else if( get_missing_watched_dir_nb() ) {
         /* One or several directories couldn't have been added to inotify watcher */
-        handle_missing_watched_dir(file_monitor_fd);
+        handle_missing_watched_dir();
     }
 
     /* Set the inotify event callbacks */

--- a/crashlog/panic.c
+++ b/crashlog/panic.c
@@ -59,6 +59,9 @@ static int check_aplogs_tobackup(char *filename) {
             LOGE("%s: Cannot transform the property %s(which is %s) into an array... error is %d - %s\n",
                 __FUNCTION__, PROP_IPANIC_PATTERN, ipanic_chain, nbpatterns, strerror(-nbpatterns));
             /* allocated memory is freed in commachain_to_fixedarray */
+            if (patterns_array_32) {
+                free(patterns_array_32);
+            }
             return 0;
         }
         if (nbpatterns == 0) {

--- a/crashlog/watchdog.c
+++ b/crashlog/watchdog.c
@@ -118,7 +118,7 @@ static void crashlog_wd_handler(int signal,
 
 int enable_watchdog(unsigned int timeout) {
     struct sigaction sigact;
-    struct sigevent sevp;
+    struct sigevent sevp = {0};
     struct itimerspec;
 
     if (timeout == 0)


### PR DESCRIPTION
1. fix the resource leak in check_aplogs_tobackup
2. fix the Memory - corruptions in add_section
3. fix Uninitialized variables in enable_watchdog
4. fix the resource leak in find_system_last_kmsg
5. fix the Uninitialized variables in do_last_kmsg_copy

Tests Done:
1. Build and boot
2. crashlog function works

Tracked-On: OAM-129199