### PR TITLE
Fix for Coverity issues for crashlog

### DIFF
--- a/crashlog/crashutils.c
+++ b/crashlog/crashutils.c
@@ -162,7 +162,7 @@ unsigned long long get_uptime(int refresh, int *error)
 }
 
 // Find system last kmsg from dropbox
-static int find_system_last_kmsg(char source[], int source_length) {
+static int find_system_last_kmsg(char *source, int source_length) {
     struct dirent *entry;
     DIR *dir;
     int file_exist = 0;
@@ -184,6 +184,7 @@ static int find_system_last_kmsg(char source[], int source_length) {
             }
         }
     }
+    closedir(dir);
     return file_exist;
 }
 
@@ -206,7 +207,7 @@ void do_last_kmsg_copy(char *dir) {
         snprintf(destion, sizeof(destion), "%s/%s", dir, FTRACE_RAMOOPS_FILE);
         do_copy_tail(FTRACE_RAMOOPS, destion, MAXFILESIZE);
     }
-    if (find_system_last_kmsg(source, sizeof(source))) {
+    if (find_system_last_kmsg(&source, sizeof(source))) {
         snprintf(destion, sizeof(destion), "%s/%s", dir, source);
         snprintf(sourcepath, sizeof(sourcepath), "%s/%s", DROPBOX_DIR, source);
         do_copy_tail(sourcepath, destion, MAXFILESIZE);


### PR DESCRIPTION
This patch fixes few coverity issues for log_capture

Tests Done: Build and boot

Original Tracked-On: OAM-122345

Test Done:

Tracked-On: